### PR TITLE
Keep interpolation symbols intact

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -5,7 +5,7 @@ PATH
       capybara (~> 2.6)
       colored (~> 1)
       midwire_common (~> 0.1)
-      optimist
+      optimist (~> 3.0)
       poltergeist (~> 1.9)
 
 GEM

--- a/lib/tr4n5l4te/runner.rb
+++ b/lib/tr4n5l4te/runner.rb
@@ -48,7 +48,7 @@ module Tr4n5l4te
 
     def translate(string)
       @count += 1
-      puts("[#{string}]") if options[:verbose]
+      puts("Translating [#{string}]") if options[:verbose]
       translator.translate(string, from_lang, options[:lang])
     end
 

--- a/lib/tr4n5l4te/translator.rb
+++ b/lib/tr4n5l4te/translator.rb
@@ -14,7 +14,6 @@ module Tr4n5l4te
     end
 
     def translate(text, from_lang, to_lang)
-      puts "Translating: #{text}"
       encoded_text = validate_and_encode(text)
       return '' if encoded_text == ''
 

--- a/spec/lib/tr4n5l4te/translator_spec.rb
+++ b/spec/lib/tr4n5l4te/translator_spec.rb
@@ -20,6 +20,20 @@ module Tr4n5l4te
           it 'does not translate ambiguous words' do
             expect(translator.translate('Friends', :en, :es)).to match(/Friends/)
           end
+
+          # rubocop:disable Style/FormatStringToken
+          it 'does not mangle interpolated text within tags', focus: true do
+            src = 'It looks like your timezone is <strong>%{zone_name}</strong>'
+            expected = 'Parece que su zona horaria es <strong> %{zone_name} </strong>'
+            expect(translator.translate(src, :en, :es)).to eq(expected)
+          end
+
+          it 'does not mangle interpolated text at the end' do
+            src = 'It looks like your timezone is %{zone_name}'
+            expected = 'Parece que tu zona horaria es %{zone_name}'
+            expect(translator.translate(src, :en, :es)).to eq(expected)
+          end
+          # rubocop:enable Style/FormatStringToken
         end
       end
     end

--- a/spec/lib/tr4n5l4te/translator_spec.rb
+++ b/spec/lib/tr4n5l4te/translator_spec.rb
@@ -22,7 +22,7 @@ module Tr4n5l4te
           end
 
           # rubocop:disable Style/FormatStringToken
-          it 'does not mangle interpolated text within tags', focus: true do
+          it 'does not mangle interpolated text within tags' do
             src = 'It looks like your timezone is <strong>%{zone_name}</strong>'
             expected = 'Parece que su zona horaria es <strong> %{zone_name} </strong>'
             expect(translator.translate(src, :en, :es)).to eq(expected)

--- a/tr4n5l4te.gemspec
+++ b/tr4n5l4te.gemspec
@@ -30,6 +30,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'capybara', '~> 2.6'
   spec.add_dependency 'colored', '~> 1'
   spec.add_dependency 'midwire_common', '~> 0.1'
-  spec.add_dependency 'optimist'
+  spec.add_dependency 'optimist', '~> 3.0'
   spec.add_dependency 'poltergeist', '~> 1.9'
 end


### PR DESCRIPTION
- [x] I wrote specs to cover new or modified code in this PR
- [x] I ran `rake spec` locally and ALL specs pass

Related Issue: #11
Description: Google has tried to get smart about symbols within the string and now adds spaces around some symbols.  This broke any interpolated symbol tags.  This PR addresses that with pre and postprocessing of the string.  Google still does wacky space injections around HTML tags et. al. but this should keep interpolation symbols intact.
